### PR TITLE
nix/s2e/env.nix: fix license declaration, undefined symbol

### DIFF
--- a/nix/s2e/env.nix
+++ b/nix/s2e/env.nix
@@ -9,7 +9,7 @@ let
     meta = {
       homepage = "https://github.com/S2E/s2e-env";
       description = "A tool to run S2E (not used by amba)";
-      license = licenses.gpl2Plus;
+      license = lib.licenses.gpl2Plus;
     };
 
     propagatedBuildInputs = let


### PR DESCRIPTION
We were missing the `lib` prefix for accessing the licence. This ment `nix run .#s2e-env` didn't work. This fixes that error.