### PR TITLE
generate compile_flags.txt easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,6 @@ get-libamba-symbols:
 		| rg -v 'GLIBC|CXXABI|GCC' \
 		| c++filt \
 		| printf "\nDynamic symbols required by libamba:\n\n$$(cat -)"
+
+compile_flags.txt:
+	make -C crates/libamba ../../compile_flags.txt

--- a/gen_compile_flags.sh
+++ b/gen_compile_flags.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Generates the compile_flags.txt for libamba by evoking the make file target.
-
-set -e
-
-script_parent=$(dirname  -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
-cd "$script_parent"
-make -j -sC crates/libamba/ compile_flags.txt


### PR DESCRIPTION
I don't want to think about what make file or target to run. Either we keep this or have a shellhook to generate compile_flags.txt even though it doesn't work for all lsp clients.