### PR TITLE
nix/patches/s2e/mapfile.replace: Expose all global symbols

### DIFF
--- a/nix/patches/s2e/mapfile.replace
+++ b/nix/patches/s2e/mapfile.replace
@@ -1,33 +1,6 @@
 {
     global:
-        open64;
-        close64;
-        write;
-        sigaction;
-        ioctl;
-        select;
-        poll;
-        mmap;
-        mmap64;
-        madvise;
-        printf;
-        fprintf;
-        dup;
-        __libc_start_main;
-        extern "C++" {
-            *s2e::Plugin;
-            klee::ObjectState::?ObjectState*;
-            llvm::APInt::countLeadingZerosSlowCase*;
-            llvm::DisableABIBreakingChecks;
-            llvm::raw_ostream::write*;
-            s2e::CompiledPlugin::s_compiledPlugins;
-            s2e::Plugin::getDebugStream*;
-            s2e::Plugin::getInfoStream*;
-            s2e::Plugin::getWarningsStream*;
-            s2e::S2EExecutionStateMemory::read*;
-            s2e::S2EExecutionStateRegisters::getCpuState*;
-            sigc::connection::connection*;
-        };
+        *;
     local:
         *;
 };


### PR DESCRIPTION
Because adding them whenever we find that something new is missing is a pain. If binary bloat becomes an issue, strip the binary later