### PR TITLE
Ändra i begreppslitan

### DIFF
--- a/doc/report/begreppslista.tex
+++ b/doc/report/begreppslista.tex
@@ -1,47 +1,47 @@
 \begin{labeling}{begreppslista}
 
-    \item [\textbf{Assembler}] (jfr. en. assembly) är ett lågnivåspråk som
+    \item [\textbf{Assembler}] (jfr.\ en.\ assembly) är ett lågnivåspråk som
     direkt kan översättas till maskinkod. Maskinkod kan inte direkt översättas
     till assembler.
 
-    \item[\textbf{Basic block}] (jfr. sv. basalt block) En sekvens av
+    \item[\textbf{Basic block}] (jfr.\ sv.\ basalt block) En sekvens av
     instruktioner som saknar hopp eller branches bortsett från början och slutet
     av blocket. Är oftast expanderade till att bli så långa som möjligt
 
-    \item [\textbf{Black-box analys}] (jfr. sv. svartlådeanalys) Analys av ett
+    \item [\textbf{Black-box analys}] (jfr.\ sv.\ svartlådeanalys) Analys av ett
     objekt som endast betraktar dess yttre utseende och beteende, till skillnad
     från white-box-analys som även betraktar vad som händer inuti.
 
-    \item [\textbf{Binär}] (jfr. en. binary) En ELF fil.
+    \item [\textbf{Binär}] (jfr.\ en.\ binary) En ELF fil.
 
-    \item [\textbf{Callbackfunktion}] (jfr. sv. ) är en funktion som läggs i en
-    hook (jfr. sv. krok) för att exekveras vid ett visst tillstånd.
+    \item [\textbf{Callbackfunktion}] (jfr.\ sv.\ ???) är en funktion som läggs i en
+    hook (jfr.\ sv.\ krok) för att exekveras vid ett visst tillstånd.
 
-    \item [\textbf{CFG}] (\emph{Control Flow Graph}, jfr. sv.
+    \item [\textbf{CFG}] (\emph{Control Flow Graph}, jfr.\ sv.\
           kontrollflödesgraf)
 
-    \item [\textbf{Conkolisk testning}] (jfr. en. Concolic Testing) är en sorts
+    \item [\textbf{Conkolisk testning}] (jfr.\ en.\ Concolic Testing) är en sorts
     fuzztesting där indata genereras genom att med en SMT-lösare lösa
     ekvationerna som beskriver en körning som ursprungligen följer körningen för
     en seed-indata, men vid ett angivet hopp avviker. Detta är en effektiv metod
     för att konstruera indata som tar 	speciella svår-tagna hopp.
 
-    \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr. sv. fånga flaggan) är i
+    \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr.\ sv.\ fånga flaggan) är i
     datorsäkerhetssammanhang är en utmaning eller övning i att hitta gömda
     "flaggor" i program med avsiktliga säkerhetshål.
 
     \item [\textbf{DWARF}] Metainformation i ELF-filer som kopplar maskinkod
     till källkod. Används vid instrumentering av ELF-filer.
 
-    \item [\textbf{Dynamisk analys}] (jfr. en. dynamic analysis) är när en binär
+    \item [\textbf{Dynamisk analys}] (jfr.\ en.\ dynamic analysis) är när en binär
     analyserar genom att exevera binären i en kontrollerad miljö för att i
     detalj registrera vad binären gör.
 
-    \item [\textbf{ELF}] (\emph{Executable and Linkable Format}, jfr. sv.
+    \item [\textbf{ELF}] (\emph{Executable and Linkable Format}, jfr.\ sv.\
           exekverbart och länkbart format). Filformatet för exekverbara filer på Unix
     och liknande system. Innehåller maskinkod och länkar till andra ELF-filer.
 
-    \item [\textbf{Exekveringsmotor}] (jfr. en. execution engine) är ett program
+    \item [\textbf{Exekveringsmotor}] (jfr.\ en.\ execution engine) är ett program
     som exekverar ett programs instruktioner.
 
     \item [\textbf{Fuzztestning}] Att slumpmässigt generera indata till ett
@@ -50,7 +50,7 @@
     indata med genetiska algoritmer och vissa använder white-box
     binärinstrumentation för att evaluera indata.
 
-    \item [\textbf{Grey-box analys}] (jfr. sv. grålådeanalys) är en teknik som
+    \item [\textbf{Grey-box analys}] (jfr.\ sv.\ grålådeanalys) är en teknik som
     kombinerar black-box och white-box för att bilda en bredare analys. Ett
     användingsområde kan vara där  dokumentationen är begränsad om ett programs
     interna struktur.
@@ -67,10 +67,10 @@
     \item [\textbf{Heuristik}] Praktisk metod för att lösa problem baserat på
     tidigare erfarenhet.
 
-    \item [\textbf{Hook}] (jfr. sv. krok) en lista på callback funktioner som
+    \item [\textbf{Hook}] (jfr.\ sv.\ krok) en lista på callback funktioner som
     ska köras vid ett specifikt tillstånd.
 
-    \item [\textbf{Instrumentering}] (jfr. en. instrumentation) mätning av ett
+    \item [\textbf{Instrumentering}] (jfr.\ en.\ instrumentation) mätning av ett
     programs prestanda. Används för att hitta buggar och hitta kontrollflöden.
 
     \item [\textbf{IPC}] (\emph{Inter-process communication}, jfr. sv. inter-
@@ -79,25 +79,25 @@
 
     \item [\textbf{KLEE}] SMT-lösaren som används av \stoe{}.
 
-    \item [\textbf{Maskinkod}] (jfr. en. machine code) är digital kod som CPUn
+    \item [\textbf{Maskinkod}] (jfr.\ en.\ machine code) är digital kod som CPUn
     kan tolka och arbeta med.
 
-    \item [\textbf{Minne}] (jfr. en. memory, även kallat primärminne och RAM-
+    \item [\textbf{Minne}] (jfr.\ en.\ memory, även kallat primärminne och RAM-
           minne) är dit ELF filer flyttas till när ELF filen ska exekveras.
 
     \item [\textbf{Operation}] En assemblerinstruktion med argument.
 
-    \item [\textbf{Path Merging}] (jfr. sv. tillståndssammanslagning) möjliggör
+    \item [\textbf{Path Merging}] (jfr.\ sv.\ tillståndssammanslagning) möjliggör
     att antingen automatiskt eller manuellt slå ihop olika stigar mellan
     tillstånd.  Använd för att öka presdandan.
 
-    \item [\textbf{Pekare}] (jfr. en. pointer) en minnesadress till ett värde på
+    \item [\textbf{Pekare}] (jfr.\ en.\ pointer) en minnesadress till ett värde på
     antingen stacken eller heapen.
 
     \item [\textbf{Process}] är miljön bestående av bland annat variabler och
     trådar där binärer exekveras.
 
-    \item [\textbf{QEMU}] (\emph{Quick Emulator}, jfr. sv. snabb emulator) är
+    \item [\textbf{QEMU}] (\emph{Quick Emulator}, jfr.\ sv.\ snabb emulator) är
     ett välunderhållet öppen källkods emulatorramverk med stöd för många
     plattformar och som stöder både user-space emulering av en process samt
     emulering av ett helt system.
@@ -106,30 +106,27 @@
     till att göra ett it-system oanvändbar genom kryptering av data som endast
     kan avkrypteras med en nyckel.
 
-    \item [\textbf{Ransomware}] Gisslanprogram. En sorts skadeprogram som syftar
-    till att göra ett it-system oanvändbar genom kryptering av data som endast
-    kan avkrypteras med en nyckel.
-
     \item [\textbf{Remote code execution}] En sårbarhet som tillåter körning av
     godtyckliga kommandon eller kod på en måldator.
 
-    \item [\textbf{Reverse Engineering}] (jfr. sv. demontering eller
+    \item [\textbf{Reverse Engineering}] (jfr.\ sv.\ demontering eller
           backlängeskonstruktion) är en process där man från en befintlig artefakt
     försöker återskapa källkodsinstruktionerna skrivna av de ursprungliga
     utvecklarna av artefakten.
 
-    \item [\textbf{Runtime}] (jfr. sv. körtid) är tidsspannet från det att ett
+    \item [\textbf{Runtime}] (jfr.\ sv.\ körtid) är tidsspannet från det att ett
     program börjar exekveras, tills dess att programmet har slutat att
     exekveras.
 
-    \item [\textbf{\stoe}] (\emph{The Selective Symbolic Execution Platform},
-          jfr. sv. ), är en platform som tillhandahåller symbolisk exekvering inuti
-    den virtuella maskinen QEMU.
+    \item [\textbf{\stoe}] \emph{The Selective Symbolic Execution Platform} är
+    en platform som tillhandahåller symbolisk exekvering inuti den virtuella
+    maskinen QEMU.\@
 
-    \item [\textbf{SMT-lösare}] (\emph{Satisfiability Modulo Theories}, jfr. sv.
-          ) är ett program som kan lösa ekvationssystem för olika matematiska objekt.
-    Exempel på teorier är modulär aritmetik eller bitvektorer. En SMT-lösare kan
-    till exempel lösa ekvationer konstruerade i symbolisk exekvering.
+    \item [\textbf{SMT-lösare}] (\emph{Satisfiability Modulo Theories}, jfr.\
+          sv.\ ???) är ett program som kan lösa ekvationssystem för olika matematiska
+    objekt.  Exempel på teorier är modulär aritmetik eller bitvektorer. En
+    SMT-lösare kan till exempel lösa ekvationer konstruerade i symbolisk
+    exekvering.
 
     \item [\textbf{Stack}] Område i minnet som reserveras för varje enskild
     tråd.  På stacken förvaras värden där man redan vid kompilering känner till
@@ -141,7 +138,7 @@
     \item [\textbf{Statisk analys}] är binäranalys där man endast utifrån
     maskinkoden på disk försöker dra slutsater om binärens beteende.
 
-    \item [\textbf{SSG}] (\emph{Sympolic State Graph}, jfr. sv. symbolisk
+    \item [\textbf{SSG}] (\emph{Sympolic State Graph}, jfr.\ sv.\ symbolisk
           tillståndsgraf)
 
     \item [\textbf{Symbolisk exekvering}] Att tilldela variabler symboliska, i
@@ -153,17 +150,17 @@
     exekvering och fuzzingtestning. Kombinationen bevarar kodstrukturen och kan
     samtidigt lösa komplexa symboliska restriktioner.
 
-    \item [\textbf{Symbolisk operation}] (jfr. en. symbolic operation)
+    \item [\textbf{Symbolisk operation}] (jfr.\ en.\ symbolic operation)
     operationer med symboliska värden.
 
-    \item [\textbf{Symbolisk värde}] (jfr. en. symbolic value) är en abstraktion
+    \item [\textbf{Symbolisk värde}] (jfr.\ en.\ symbolic value) är en abstraktion
     av konkreta värden som representeras av en variabel. Möjliggör att analysera
     samtliga möjliga värden.
 
-    \item [\textbf{Tråd}] (jfr. en. thread) är den delen av processer som utför
+    \item [\textbf{Tråd}] (jfr.\ en.\ thread) är den delen av processer som utför
     operationerna i en ELF fil. Varje process har en eller flera trådar.
 
-    \item [\textbf{White-box analys}] (jfr. sv. vitlådsanalys) är en analysmetod
+    \item [\textbf{White-box analys}] (jfr.\ sv.\ vitlådsanalys) är en analysmetod
     som behandlar en applikations interna struktur i kontrast till black-box
     analys som enbart betraktar funktionaliteten.
 

--- a/doc/report/begreppslista.tex
+++ b/doc/report/begreppslista.tex
@@ -1,167 +1,190 @@
 \begin{labeling}{begreppslista}
 
     \item [\textbf{Assembler}] (jfr.\ en.\ assembly) är ett
-    lågnivåspråk som direkt kan översättas till
-    maskinkod.
+    lågnivåspråk som direkt kan översättas till maskinkod.
 
-    \item[\textbf{Basic block}] (jfr.\ sv.\ basalt block) En sekvens av
-    instruktioner som saknar hopp eller branches bortsett från början och slutet
-    av blocket. Är oftast expanderade till att bli så långa som möjligt
+    \item[\textbf{Basic block}] (jfr.\ sv.\ grundblock) En sekvens av
+    instruktioner som saknar hopp eller branches bortsett från
+    början och slutet av blocket. Är oftast expanderade till att
+    bli så långa som möjligt
 
-    \item [\textbf{Black-box analys}] (jfr.\ sv.\ svartlådeanalys) Analys av ett
-    objekt som endast betraktar dess yttre utseende och beteende, till skillnad
-    från white-box-analys som även betraktar vad som händer inuti.
+    \item [\textbf{Black-box analys}] (jfr.\ sv.\ svartlådeanalys)
+    Analys av ett objekt som endast betraktar dess yttre utseende
+    och beteende, till skillnad från white-box-analys som även
+    betraktar vad som händer inuti.
 
     \item [\textbf{Binär}] (jfr.\ en.\ binary) En ELF fil.
 
-    \item [\textbf{Callbackfunktion}] (jfr.\ sv.\ ???) är en funktion som läggs i en
-    hook (jfr.\ sv.\ krok) för att exekveras vid ett visst tillstånd.
+    \item [\textbf{Callbackfunktion}] (jfr.\ sv.\ ???) är en funktion
+    som läggs i en hook (jfr.\ sv.\ krok) för att exekveras vid
+    ett visst tillstånd.
 
-    \item [\textbf{CFG}] (\emph{Control Flow Graph}, jfr.\ sv.\
-          kontrollflödesgraf)
+    \item [\textbf{CFG}] (\emph{Control Flow Graph},
+          jfr.\ sv.\ kontrollflödesgraf)
 
-    \item [\textbf{Conkolisk testning}] (jfr.\ en.\ Concolic Testing) är en sorts
-    fuzztesting där indata genereras genom att med en SMT-lösare lösa
-    ekvationerna som beskriver en körning som ursprungligen följer körningen för
-    en seed-indata, men vid ett angivet hopp avviker. Detta är en effektiv metod
-    för att konstruera indata som tar speciella svårtagna hopp.
+    \item [\textbf{Conkolisk testning}] (jfr.\ en.\ Concolic Testing)
+    är en sorts fuzztesting där indata genereras genom att med en
+    SMT-lösare lösa ekvationerna som beskriver en körning som
+    ursprungligen följer körningen för en seed-indata, men vid ett
+    angivet hopp avviker. Detta är en effektiv metod för att
+    konstruera indata som tar speciella svårtagna hopp.
 
-    \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr.\ sv.\ fånga flaggan) är i
-    datorsäkerhetssammanhang är en utmaning eller övning i att hitta gömda
-    "flaggor" i program med avsiktliga säkerhetshål.
+    \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr.\ sv.\ fånga
+          flaggan) är i datorsäkerhetssammanhang är en utmaning eller
+    övning i att hitta gömda "flaggor" i program med avsiktliga
+    säkerhetshål.
 
-    \item [\textbf{Dwarf}] Metainformation i ELF-filer som kopplar maskinkod
-    till källkod. Används vid instrumentering av ELF-filer.
+    \item [\textbf{Dwarf}] Metainformation i ELF-filer som kopplar
+    maskinkod till källkod. Används vid instrumentering av
+    ELF-filer.
 
-    \item [\textbf{Dynamisk analys}] (jfr.\ en.\ dynamic analysis) är när en binär
-    analyserar genom att exevera binären i en kontrollerad miljö för att i
-    detalj registrera vad binären gör.
+    \item [\textbf{Dynamisk analys}] (jfr.\ en.\ dynamic analysis) är
+    när en binär analyserar genom att exevera binären i en
+    kontrollerad miljö för att i detalj registrera vad binären
+    gör.
 
-    \item [\textbf{ELF}] (\emph{Executable and Linkable Format}, jfr.\ sv.\
-          exekverbart och länkbart format). Filformatet för exekverbara filer på Unix
-    och liknande system. Innehåller maskinkod och länkar till andra ELF-filer.
+    \item [\textbf{ELF}] (\emph{Executable and Linkable Format},
+          jfr.\ sv.\ exekverbart och länkbart format). Filformatet för
+    exekverbara filer på Unix och liknande system. Innehåller
+    maskinkod och länkar till andra ELF-filer.
 
-    \item [\textbf{Exekveringsmotor}] (jfr.\ en.\ execution engine) är ett program
-    som exekverar ett programs instruktioner.
+    \item [\textbf{Exekveringsmotor}] (jfr.\ en.\ execution engine) är
+    ett program som exekverar ett programs instruktioner.
 
-    \item [\textbf{Fuzztestning}] Att slumpmässigt generera indata till ett
-    system i ett försök att hitta buggar eller genom frånvaron av dåligt
-    beteende betryggas i systemets kvalité. Vissa fuzztestmotorer genererar ny
-    indata med genetiska algoritmer och vissa använder white-box
+    \item [\textbf{Fuzztestning}] Att slumpmässigt generera indata
+    till ett system i ett försök att hitta buggar eller genom
+    frånvaron av dåligt beteende betryggas i systemets
+    kvalité. Vissa fuzztestmotorer genererar ny indata med
+    genetiska algoritmer och vissa använder white-box
     binärinstrumentation för att evaluera indata.
 
-    \item [\textbf{Grey-box analys}] (jfr.\ sv.\ grålådeanalys) är en teknik som
-    kombinerar black-box och white-box för att bilda en bredare analys. Ett
-    användingsområde kan vara där  dokumentationen är begränsad om ett programs
-    interna struktur.
+    \item [\textbf{Grey-box analys}] (jfr.\ sv.\ grålådeanalys) är en
+    teknik som kombinerar black-box och white-box för att bilda en
+    bredare analys. Ett användingsområde kan vara där
+    dokumentationen är begränsad om ett programs interna struktur.
 
-    \item [\textbf{Grid of equals}] Designmönster inom interaktionsdesign för
-    utveckling av grafiska gränssnitt där innehållet organiseras i geometriska
-    former, ofta rektanglar som innehåller bild eller text och som placeras i
-    lika avstånd till varandra och alla andra element.
+    \item [\textbf{Grid of equals}] Designmönster inom
+    interaktionsdesign för utveckling av grafiska gränssnitt där
+    innehållet organiseras i geometriska former, ofta rektanglar
+    som innehåller bild eller text och som placeras i lika avstånd
+    till varandra och alla andra element.
 
-    \item [\textbf{Heap}] Område i minnet som samtliga trådar i en process har
-    tillgång till. Används för objekt där man inte vet storleken innan man
-    exeverar programmet; samt objekt som ska delas mellan en process trådar.
+    \item [\textbf{Heap}] Område i minnet som samtliga trådar i en
+    process har tillgång till. Används för objekt där man inte vet
+    storleken innan man exeverar programmet; samt objekt som ska
+    delas mellan en process trådar.
 
-    \item [\textbf{Heuristik}] Praktisk metod för att lösa problem baserat på
-    tidigare erfarenhet.
+    \item [\textbf{Heuristik}] Praktisk metod för att lösa problem
+    baserat på tidigare erfarenhet.
 
-    \item [\textbf{Hook}] (jfr.\ sv.\ krok) en lista på callback funktioner som
-    ska köras vid ett specifikt tillstånd.
+    \item [\textbf{Hook}] (jfr.\ sv.\ krok) en lista på callback
+    funktioner som ska köras vid ett specifikt tillstånd.
 
-    \item [\textbf{Instrumentering}] (jfr.\ en.\ instrumentation) mätning av ett
-    programs prestanda. Används för att hitta buggar och hitta kontrollflöden.
+    \item [\textbf{Instrumentering}] (jfr.\ en.\ instrumentation)
+    mätning av ett programs prestanda. Används för att hitta
+    buggar och hitta kontrollflöden.
 
     \item [\textbf{IPC}] (\emph{Inter-process communication}, jfr. sv.
-          interprocesskommunikation) är ett samlingsbegrepp på olika tekniker för att
-    trådar i olika processer att kommunicera med varandra.
+          interprocesskommunikation) är ett samlingsbegrepp på olika
+    tekniker för att trådar i olika processer att kommunicera med
+    varandra.
 
-    \item [\textbf{KLEE}] SMT-lösaren som används av \stoe{}.
+    \item [\textbf{KLEE}] Den symboliska exekveringsmotorn som används
+    av \stoe{}.
 
-    \item [\textbf{Maskinkod}] (jfr.\ en.\ machine code) är digital kod som CPUn
-    kan tolka och arbeta med.
+    \item [\textbf{Maskinkod}] (jfr.\ en.\ machine code) är digital
+    kod som CPUn kan tolka och arbeta med.
 
-    \item [\textbf{Minne}] (jfr.\ en.\ memory, även kallat primärminne och RAM-
-          minne) är dit ELF filer flyttas till när ELF filen ska exekveras.
+    \item [\textbf{Minne}] (jfr.\ en.\ memory, även kallat primärminne
+          och RAM- minne) är dit ELF filer flyttas till när ELF filen
+    ska exekveras.
 
     \item [\textbf{Operation}] En assemblerinstruktion med argument.
 
-    \item [\textbf{Path Merging}] (jfr.\ sv.\ tillståndssammanslagning) möjliggör
-    att antingen automatiskt eller manuellt slå ihop olika stigar mellan
+    \item [\textbf{Path Merging}]
+          (jfr.\ sv.\ tillståndssammanslagning) möjliggör att antingen
+    automatiskt eller manuellt slå ihop olika stigar mellan
     tillstånd.  Använd för att öka presdandan.
 
-    \item [\textbf{Pekare}] (jfr.\ en.\ pointer) en minnesadress till ett värde på
-    antingen stacken eller heapen.
+    \item [\textbf{Pekare}] (jfr.\ en.\ pointer) en minnesadress som
+    vanligtvis pekar på ett värde på stacken eller heapen.
 
-    \item [\textbf{Process}] är miljön bestående av bland annat variabler och
-    trådar där binärer exekveras.
+    \item [\textbf{Process}] En process är en
+    operativsystemabstraktion som speciellt innehåller en memory
+    map(jfr sv. minneskarta) tillsammans med ett antal trådar och
+    andra operativsystemsresurser såsom fildeskriptorer (jfr
+    en. File descriptor)
 
-    \item [\textbf{QEMU}] (\emph{Quick Emulator}, jfr.\ sv.\ snabb emulator) är
-    ett välunderhållet öppen källkods emulatorramverk med stöd för många
-    plattformar och som stöder både user-space emulering av en process samt
-    emulering av ett helt system.
+    \item [\textbf{QEMU}] (\emph{Quick Emulator}, jfr.\ sv.\ snabb
+          emulator) är ett välunderhållet öppen källkods emulatorramverk
+    med stöd för många plattformar och som stöder både user-space
+    emulering av en process samt emulering av ett helt system.
 
-    \item [\textbf{Ransomware}] Gisslanprogram. En sorts skadeprogram som syftar
-    till att göra ett it-system oanvändbar genom kryptering av data som endast
-    kan avkrypteras med en nyckel.
+    \item [\textbf{Ransomware}] Gisslanprogram. En sorts skadeprogram
+    som syftar till att göra ett it-system oanvändbar genom
+    kryptering av data som endast kan avkrypteras med en nyckel.
 
-    \item [\textbf{Remote code execution}] En sårbarhet som tillåter körning av
-    godtyckliga kommandon eller kod på en måldator.
+    \item [\textbf{Remote code execution}] En sårbarhet som tillåter
+    körning av godtyckliga kommandon eller kod på en måldator.
 
     \item [\textbf{Reverse Engineering}] (jfr.\ sv.\ demontering eller
-          backlängeskonstruktion) är en process där man från en befintlig artefakt
-    försöker återskapa källkodsinstruktionerna skrivna av de ursprungliga
-    utvecklarna av artefakten.
+          backlängeskonstruktion) är en process där man från en
+    befintlig artefakt försöker återskapa källkodsinstruktionerna
+    skrivna av de ursprungliga utvecklarna av artefakten.
 
-    \item [\textbf{Runtime}] (jfr.\ sv.\ körtid) är tidsspannet från det att ett
-    program börjar exekveras, tills dess att programmet har slutat att
-    exekveras.
+    \item [\textbf{Runtime}] (jfr.\ sv.\ körtid) är tidsspannet från
+    det att ett program börjar exekveras, tills dess att
+    programmet har slutat att exekveras.
 
-    \item [\textbf{\stoe}] \emph{The Selective Symbolic Execution Platform} är
-    en platform som tillhandahåller symbolisk exekvering inuti den virtuella
-    maskinen QEMU.\@
+    \item [\textbf{\stoe}] \emph{The Symbolic Execution Platform} är
+    en platform som tillhandahåller symbolisk exekvering inuti den
+    virtuella maskinen QEMU.\@
 
-    \item [\textbf{SMT-lösare}] (\emph{Satisfiability Modulo Theories}, jfr.\
-          sv.\ ???) är ett program som kan lösa ekvationssystem för olika matematiska
-    objekt.  Exempel på teorier är modulär aritmetik eller bitvektorer. En
-    SMT-lösare kan till exempel lösa ekvationer konstruerade i symbolisk
+    \item [\textbf{SMT-lösare}] (\emph{Satisfiability Modulo
+              Theories}, jfr.\ sv.\ ???) är ett program som kan lösa
+    ekvationssystem för olika matematiska objekt.  Exempel på
+    teorier är modulär aritmetik eller bitvektorer. En SMT-lösare
+    kan till exempel lösa ekvationer konstruerade i symbolisk
     exekvering.
 
-    \item [\textbf{Stack}] Område i minnet som reserveras för varje enskild
-    tråd.  På stacken förvaras värden där man redan vid kompilering känner till
-    värdets minnesstorlek.
+    \item [\textbf{Stack}] Område i minnet som reserveras för varje
+    enskild tråd.  På stacken förvaras värden där man redan vid
+    kompilering känner till värdets minnesstorlek.
 
-    \item [\textbf{Starkt kopplade komponenter}] En riktad delgraf där varje nod
-    har en väg sådant att det går att nå alla andra noder i delgrafen.
+    \item [\textbf{Starkt anslutna komponenter}] (jfr.\ en.\ Strongly
+          Connected Components) En riktad delgraf där varje nod har en
+    väg sådant att det går att nå alla andra noder i delgrafen.
 
-    \item [\textbf{Statisk analys}] är binäranalys där man endast utifrån
-    maskinkoden på disk försöker dra slutsater om binärens beteende.
+    \item [\textbf{Statisk analys}] är binäranalys där man endast
+    utifrån maskinkoden på disk försöker dra slutsater om binärens
+    beteende.
 
-    \item [\textbf{SSG}] (\emph{Sympolic State Graph}, jfr.\ sv.\ symbolisk
-          tillståndsgraf)
+    \item [\textbf{SSG}] (\emph{Sympolic State Graph},
+          jfr.\ sv.\ symbolisk tillståndsgraf)
 
-    \item [\textbf{Symbolisk exekvering}] Att tilldela variabler symboliska, i
-    motsats till konkreta värden under programmets exekvering. Med denna
-    analysteknik kan enskilda körningar ge information som annars hade krävt en
-    uttömmande sökning.
+    \item [\textbf{Symbolisk exekvering}] Att tilldela variabler
+    symboliska, i motsats till konkreta värden under programmets
+    exekvering. Med denna analysteknik kan enskilda körningar ge
+    information som annars hade krävt en uttömmande sökning.
 
-    \item [\textbf{Symbolisk fuzztestning}] Teknik som kombinerar symbolisk
-    exekvering och fuzzingtestning. Kombinationen bevarar kodstrukturen och kan
-    samtidigt lösa komplexa symboliska restriktioner.
+    \item [\textbf{Symbolisk fuzztestning}] Teknik som kombinerar
+    symbolisk exekvering och fuzzingtestning. Kombinationen
+    bevarar kodstrukturen och kan samtidigt lösa komplexa
+    symboliska restriktioner.
 
-    \item [\textbf{Symbolisk operation}] (jfr.\ en.\ symbolic operation)
-    operationer med symboliska värden.
+    \item [\textbf{Symbolisk operation}] (jfr.\ en.\ symbolic
+          operation) operationer med symboliska värden.
 
-    \item [\textbf{Symbolisk värde}] (jfr.\ en.\ symbolic value) är en abstraktion
-    av konkreta värden som representeras av en variabel. Möjliggör att analysera
-    samtliga möjliga värden.
+    \item [\textbf{Symbolisk värde}] (jfr.\ en.\ symbolic value) är en
+    abstraktion av konkreta värden som representeras av en
+    variabel. Möjliggör att analysera samtliga möjliga värden.
 
-    \item [\textbf{Tråd}] (jfr.\ en.\ thread) är den delen av processer som utför
-    operationerna i en ELF fil. Varje process har en eller flera trådar.
+    \item [\textbf{Tråd}] (jfr.\ en.\ thread) är en av flera
+    parallella instruktionssekvenser inom en process.
 
-    \item [\textbf{White-box analys}] (jfr.\ sv.\ vitlådsanalys) är en analysmetod
-    som behandlar en applikations interna struktur i kontrast till black-box
-    analys som enbart betraktar funktionaliteten.
+    \item [\textbf{White-box analys}] (jfr.\ sv.\ vitlådsanalys) är en
+    analysmetod som behandlar en applikations interna struktur i
+    kontrast till black-box analys som enbart betraktar
+    funktionaliteten.
 
 \end{labeling}

--- a/doc/report/begreppslista.tex
+++ b/doc/report/begreppslista.tex
@@ -24,13 +24,13 @@
     fuzztesting där indata genereras genom att med en SMT-lösare lösa
     ekvationerna som beskriver en körning som ursprungligen följer körningen för
     en seed-indata, men vid ett angivet hopp avviker. Detta är en effektiv metod
-    för att konstruera indata som tar 	speciella svår-tagna hopp.
+    för att konstruera indata som tar speciella svårtagna hopp.
 
     \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr.\ sv.\ fånga flaggan) är i
     datorsäkerhetssammanhang är en utmaning eller övning i att hitta gömda
     "flaggor" i program med avsiktliga säkerhetshål.
 
-    \item [\textbf{DWARF}] Metainformation i ELF-filer som kopplar maskinkod
+    \item [\textbf{Dwarf}] Metainformation i ELF-filer som kopplar maskinkod
     till källkod. Används vid instrumentering av ELF-filer.
 
     \item [\textbf{Dynamisk analys}] (jfr.\ en.\ dynamic analysis) är när en binär
@@ -73,8 +73,8 @@
     \item [\textbf{Instrumentering}] (jfr.\ en.\ instrumentation) mätning av ett
     programs prestanda. Används för att hitta buggar och hitta kontrollflöden.
 
-    \item [\textbf{IPC}] (\emph{Inter-process communication}, jfr. sv. inter-
-          process kommunikation) är ett samlingsbegrepp på olika tekniker för att
+    \item [\textbf{IPC}] (\emph{Inter-process communication}, jfr. sv.
+          interprocesskommunikation) är ett samlingsbegrepp på olika tekniker för att
     trådar i olika processer att kommunicera med varandra.
 
     \item [\textbf{KLEE}] SMT-lösaren som används av \stoe{}.

--- a/doc/report/begreppslista.tex
+++ b/doc/report/begreppslista.tex
@@ -1,8 +1,8 @@
 \begin{labeling}{begreppslista}
 
-    \item [\textbf{Assembler}] (jfr.\ en.\ assembly) är ett lågnivåspråk som
-    direkt kan översättas till maskinkod. Maskinkod kan inte direkt översättas
-    till assembler.
+    \item [\textbf{Assembler}] (jfr.\ en.\ assembly) är ett
+    lågnivåspråk som direkt kan översättas till
+    maskinkod.
 
     \item[\textbf{Basic block}] (jfr.\ sv.\ basalt block) En sekvens av
     instruktioner som saknar hopp eller branches bortsett från början och slutet

--- a/doc/report/begreppslista.tex
+++ b/doc/report/begreppslista.tex
@@ -1,73 +1,167 @@
 \begin{labeling}{begreppslista}
 
-    \item[\textbf{Basic block}] (jfr. sv. basalt block) En sekvens av instruktioner som saknar
-    hopp eller branches bortsett från början och slutet av
-    blocket. Är oftast expanderade till att bli så långa som möjligt
+    \item [\textbf{Assembler}] (jfr. en. assembly) är ett lågnivåspråk som
+    direkt kan översättas till maskinkod. Maskinkod kan inte direkt översättas
+    till assembler.
 
-    \item [\textbf{Black-box analys}] (jfr. sv. svartlådeanalys) Analys av ett objekt som endast betraktar dess
-    yttre utseende och beteende, till skillnad från white-box-analys som även
-    betraktar vad som händer inuti.
+    \item[\textbf{Basic block}] (jfr. sv. basalt block) En sekvens av
+    instruktioner som saknar hopp eller branches bortsett från början och slutet
+    av blocket. Är oftast expanderade till att bli så långa som möjligt
 
-    \item [\textbf{Concolic testning}] En sorts fuzztesting där indata genereras
-    genom att med en SMT-lösare lösa ekvationerna som beskriver en körning som
-    ursprungligen följer körningen för en seed-indata, men vid ett angivet
-    hopp avviker. Detta är en effektiv metod för att konstruera indata som tar
-    speciella svår-tagna hopp.
+    \item [\textbf{Black-box analys}] (jfr. sv. svartlådeanalys) Analys av ett
+    objekt som endast betraktar dess yttre utseende och beteende, till skillnad
+    från white-box-analys som även betraktar vad som händer inuti.
 
-    \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr. sv. fånga flaggan) är
-    i datorsäkerhetssammanhang är en utmaning eller övning i att hitta gömda
+    \item [\textbf{Binär}] (jfr. en. binary) En ELF fil.
+
+    \item [\textbf{Callbackfunktion}] (jfr. sv. ) är en funktion som läggs i en
+    hook (jfr. sv. krok) för att exekveras vid ett visst tillstånd.
+
+    \item [\textbf{CFG}] (\emph{Control Flow Graph}, jfr. sv.
+          kontrollflödesgraf)
+
+    \item [\textbf{Conkolisk testning}] (jfr. en. Concolic Testing) är en sorts
+    fuzztesting där indata genereras genom att med en SMT-lösare lösa
+    ekvationerna som beskriver en körning som ursprungligen följer körningen för
+    en seed-indata, men vid ett angivet hopp avviker. Detta är en effektiv metod
+    för att konstruera indata som tar 	speciella svår-tagna hopp.
+
+    \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr. sv. fånga flaggan) är i
+    datorsäkerhetssammanhang är en utmaning eller övning i att hitta gömda
     "flaggor" i program med avsiktliga säkerhetshål.
 
-    \item [\textbf{ELF}] (\emph{Executable and Linkable Format}, jfr. sv. exekverbart och länkbart format). Filformatet för
-    exekverbara filer på Unix.
+    \item [\textbf{DWARF}] Metainformation i ELF-filer som kopplar maskinkod
+    till källkod. Används vid instrumentering av ELF-filer.
 
-    \item [\textbf{Fuzztestning}] Att slumpmässigt generera indata till ett system i
-    ett försök att hitta buggar eller genom frånvaron av dåligt beteende
-    betryggas i systemets kvalité. Vissa fuzztestmotorer genererar ny indata
-    med genetiska algoritmer och vissa använder white-box binärinstrumentation
-    för att evaluera indata.
+    \item [\textbf{Dynamisk analys}] (jfr. en. dynamic analysis) är när en binär
+    analyserar genom att exevera binären i en kontrollerad miljö för att i
+    detalj registrera vad binären gör.
 
-    \item [\textbf{Grey-box analys}] (jfr. sv. grålådeanalys) är en teknik som kombinerar black-box och
-    white-box för att bilda en bredare analys. Ett användingsområde kan vara där
-    dokumentationen är begränsad om ett programs interna struktur.
+    \item [\textbf{ELF}] (\emph{Executable and Linkable Format}, jfr. sv.
+          exekverbart och länkbart format). Filformatet för exekverbara filer på Unix
+    och liknande system. Innehåller maskinkod och länkar till andra ELF-filer.
+
+    \item [\textbf{Exekveringsmotor}] (jfr. en. execution engine) är ett program
+    som exekverar ett programs instruktioner.
+
+    \item [\textbf{Fuzztestning}] Att slumpmässigt generera indata till ett
+    system i ett försök att hitta buggar eller genom frånvaron av dåligt
+    beteende betryggas i systemets kvalité. Vissa fuzztestmotorer genererar ny
+    indata med genetiska algoritmer och vissa använder white-box
+    binärinstrumentation för att evaluera indata.
+
+    \item [\textbf{Grey-box analys}] (jfr. sv. grålådeanalys) är en teknik som
+    kombinerar black-box och white-box för att bilda en bredare analys. Ett
+    användingsområde kan vara där  dokumentationen är begränsad om ett programs
+    interna struktur.
 
     \item [\textbf{Grid of equals}] Designmönster inom interaktionsdesign för
     utveckling av grafiska gränssnitt där innehållet organiseras i geometriska
     former, ofta rektanglar som innehåller bild eller text och som placeras i
     lika avstånd till varandra och alla andra element.
 
-    \item [\textbf{QEMU}] (\emph{Quick Emulator}, jfr. sv. snabb emulator) är ett
-    välunderhållet öppen källkods emulatorramverk med stöd för många plattformar
-    och som stöder både user-space emulering av en process samt emulering av ett
-    helt system.
+    \item [\textbf{Heap}] Område i minnet som samtliga trådar i en process har
+    tillgång till. Används för objekt där man inte vet storleken innan man
+    exeverar programmet; samt objekt som ska delas mellan en process trådar.
+
+    \item [\textbf{Heuristik}] Praktisk metod för att lösa problem baserat på
+    tidigare erfarenhet.
+
+    \item [\textbf{Hook}] (jfr. sv. krok) en lista på callback funktioner som
+    ska köras vid ett specifikt tillstånd.
+
+    \item [\textbf{Instrumentering}] (jfr. en. instrumentation) mätning av ett
+    programs prestanda. Används för att hitta buggar och hitta kontrollflöden.
+
+    \item [\textbf{IPC}] (\emph{Inter-process communication}, jfr. sv. inter-
+          process kommunikation) är ett samlingsbegrepp på olika tekniker för att
+    trådar i olika processer att kommunicera med varandra.
+
+    \item [\textbf{KLEE}] SMT-lösaren som används av \stoe{}.
+
+    \item [\textbf{Maskinkod}] (jfr. en. machine code) är digital kod som CPUn
+    kan tolka och arbeta med.
+
+    \item [\textbf{Minne}] (jfr. en. memory, även kallat primärminne och RAM-
+          minne) är dit ELF filer flyttas till när ELF filen ska exekveras.
+
+    \item [\textbf{Operation}] En assemblerinstruktion med argument.
+
+    \item [\textbf{Path Merging}] (jfr. sv. tillståndssammanslagning) möjliggör
+    att antingen automatiskt eller manuellt slå ihop olika stigar mellan
+    tillstånd.  Använd för att öka presdandan.
+
+    \item [\textbf{Pekare}] (jfr. en. pointer) en minnesadress till ett värde på
+    antingen stacken eller heapen.
+
+    \item [\textbf{Process}] är miljön bestående av bland annat variabler och
+    trådar där binärer exekveras.
+
+    \item [\textbf{QEMU}] (\emph{Quick Emulator}, jfr. sv. snabb emulator) är
+    ett välunderhållet öppen källkods emulatorramverk med stöd för många
+    plattformar och som stöder både user-space emulering av en process samt
+    emulering av ett helt system.
 
     \item [\textbf{Ransomware}] Gisslanprogram. En sorts skadeprogram som syftar
-    till att göra ett it-system oanvändbar genom kryptering av data som
-    endast kan avkrypteras med en nyckel.
+    till att göra ett it-system oanvändbar genom kryptering av data som endast
+    kan avkrypteras med en nyckel.
+
+    \item [\textbf{Ransomware}] Gisslanprogram. En sorts skadeprogram som syftar
+    till att göra ett it-system oanvändbar genom kryptering av data som endast
+    kan avkrypteras med en nyckel.
 
     \item [\textbf{Remote code execution}] En sårbarhet som tillåter körning av
     godtyckliga kommandon eller kod på en måldator.
 
-    \item [\textbf{\stoe}] (\emph{The Selective Symbolic Execution Platform}, jfr. sv. ), är
-    en platform som tillhandahåller symbolisk exekvering inuti den virtuella
-    maskinen QEMU.
+    \item [\textbf{Reverse Engineering}] (jfr. sv. demontering eller
+          backlängeskonstruktion) är en process där man från en befintlig artefakt
+    försöker återskapa källkodsinstruktionerna skrivna av de ursprungliga
+    utvecklarna av artefakten.
 
-    \item [\textbf{SMT-lösare}] (\emph{Satisfiability Modulo Theories}, jfr. sv. ) är ett
-    program som kan lösa ekvationssystem för olika matematiska objekt. Exempel
-    på teorier är modulär aritmetik eller bitvektorer. En SMT-lösare kan till
-    exempel lösa ekvationer konstruerade i symbolisk exekvering.
+    \item [\textbf{Runtime}] (jfr. sv. körtid) är tidsspannet från det att ett
+    program börjar exekveras, tills dess att programmet har slutat att
+    exekveras.
 
-    \item [\textbf{Starkt kopplade komponenter}] En riktad delgraf där
-    varje nod har en väg sådant att det går att nå alla andra noder i delgrafen.
+    \item [\textbf{\stoe}] (\emph{The Selective Symbolic Execution Platform},
+          jfr. sv. ), är en platform som tillhandahåller symbolisk exekvering inuti
+    den virtuella maskinen QEMU.
+
+    \item [\textbf{SMT-lösare}] (\emph{Satisfiability Modulo Theories}, jfr. sv.
+          ) är ett program som kan lösa ekvationssystem för olika matematiska objekt.
+    Exempel på teorier är modulär aritmetik eller bitvektorer. En SMT-lösare kan
+    till exempel lösa ekvationer konstruerade i symbolisk exekvering.
+
+    \item [\textbf{Stack}] Område i minnet som reserveras för varje enskild
+    tråd.  På stacken förvaras värden där man redan vid kompilering känner till
+    värdets minnesstorlek.
+
+    \item [\textbf{Starkt kopplade komponenter}] En riktad delgraf där varje nod
+    har en väg sådant att det går att nå alla andra noder i delgrafen.
+
+    \item [\textbf{Statisk analys}] är binäranalys där man endast utifrån
+    maskinkoden på disk försöker dra slutsater om binärens beteende.
+
+    \item [\textbf{SSG}] (\emph{Sympolic State Graph}, jfr. sv. symbolisk
+          tillståndsgraf)
 
     \item [\textbf{Symbolisk exekvering}] Att tilldela variabler symboliska, i
     motsats till konkreta värden under programmets exekvering. Med denna
-    analysteknik kan enskilda körningar ge information som annars hade krävt
-    en uttömmande sökning.
+    analysteknik kan enskilda körningar ge information som annars hade krävt en
+    uttömmande sökning.
 
-    \item [\textbf{Symbolisk fuzztestning}] Teknik som kombinerar symbolisk exekvering
-    och fuzzingtestning. Kombinationen  bevarar kodstrukturen och kan samtidigt
-    lösa komplexa symboliska restriktioner.
+    \item [\textbf{Symbolisk fuzztestning}] Teknik som kombinerar symbolisk
+    exekvering och fuzzingtestning. Kombinationen bevarar kodstrukturen och kan
+    samtidigt lösa komplexa symboliska restriktioner.
+
+    \item [\textbf{Symbolisk operation}] (jfr. en. symbolic operation)
+    operationer med symboliska värden.
+
+    \item [\textbf{Symbolisk värde}] (jfr. en. symbolic value) är en abstraktion
+    av konkreta värden som representeras av en variabel. Möjliggör att analysera
+    samtliga möjliga värden.
+
+    \item [\textbf{Tråd}] (jfr. en. thread) är den delen av processer som utför
+    operationerna i en ELF fil. Varje process har en eller flera trådar.
 
     \item [\textbf{White-box analys}] (jfr. sv. vitlådsanalys) är en analysmetod
     som behandlar en applikations interna struktur i kontrast till black-box

--- a/doc/report/begreppslista.tex
+++ b/doc/report/begreppslista.tex
@@ -1,33 +1,33 @@
 \begin{labeling}{begreppslista}
 
-    \item[\textbf{Basic block}] En sekvens av instruktioner som saknar
+    \item[\textbf{Basic block}] (jfr. sv. basalt block) En sekvens av instruktioner som saknar
     hopp eller branches bortsett från början och slutet av
     blocket. Är oftast expanderade till att bli så långa som möjligt
 
-    \item [\textbf{Black-box}] Analys av ett objekt som endast betraktar dess
+    \item [\textbf{Black-box analys}] (jfr. sv. svartlådeanalys) Analys av ett objekt som endast betraktar dess
     yttre utseende och beteende, till skillnad från white-box-analys som även
     betraktar vad som händer inuti.
 
-    \item [\textbf{Concolic testing}] En sorts fuzztesting där indata genereras
+    \item [\textbf{Concolic testning}] En sorts fuzztesting där indata genereras
     genom att med en SMT-lösare lösa ekvationerna som beskriver en körning som
     ursprungligen följer körningen för en seed-indata, men vid ett angivet
     hopp avviker. Detta är en effektiv metod för att konstruera indata som tar
     speciella svår-tagna hopp.
 
-    \item [\textbf{CTF}] CTF, eller Capture the Flag i ett
-    datorsäkerhetssammanhang är en utmaning eller övning i
-    att hitta gömda ''flaggor'' i program med avsiktliga säkerhetshål.
+    \item [\textbf{CTF}] (\emph{Capture the Flag}, jfr. sv. fånga flaggan) är
+    i datorsäkerhetssammanhang är en utmaning eller övning i att hitta gömda
+    "flaggor" i program med avsiktliga säkerhetshål.
 
-    \item [\textbf{ELF}] \emph{Executable and Linkable Format}. Filformatet för
+    \item [\textbf{ELF}] (\emph{Executable and Linkable Format}, jfr. sv. exekverbart och länkbart format). Filformatet för
     exekverbara filer på Unix.
 
-    \item [\textbf{Fuzzing}] Att slumpmässigt generera indata till ett system i
+    \item [\textbf{Fuzztestning}] Att slumpmässigt generera indata till ett system i
     ett försök att hitta buggar eller genom frånvaron av dåligt beteende
     betryggas i systemets kvalité. Vissa fuzztestmotorer genererar ny indata
     med genetiska algoritmer och vissa använder white-box binärinstrumentation
     för att evaluera indata.
 
-    \item [\textbf{Grey-box}] Grey-box är en teknik som kombinerar black-box och
+    \item [\textbf{Grey-box analys}] (jfr. sv. grålådeanalys) är en teknik som kombinerar black-box och
     white-box för att bilda en bredare analys. Ett användingsområde kan vara där
     dokumentationen är begränsad om ett programs interna struktur.
 
@@ -36,15 +36,23 @@
     former, ofta rektanglar som innehåller bild eller text och som placeras i
     lika avstånd till varandra och alla andra element.
 
-    \item [\textbf{QEMU}] Ett välunderhållet öppen källkods emulatorramverk med stöd
-    för många plattformar och som stöder både user-space emulering av en process
-    samt emulering av ett helt system.
+    \item [\textbf{QEMU}] (\emph{Quick Emulator}, jfr. sv. snabb emulator) är ett
+    välunderhållet öppen källkods emulatorramverk med stöd för många plattformar
+    och som stöder både user-space emulering av en process samt emulering av ett
+    helt system.
 
-    \item [\textbf{\stoe}] \stoe, eller \emph{The Selective Symbolic Execution Platform}, är
+    \item [\textbf{Ransomware}] Gisslanprogram. En sorts skadeprogram som syftar
+    till att göra ett it-system oanvändbar genom kryptering av data som
+    endast kan avkrypteras med en nyckel.
+
+    \item [\textbf{Remote code execution}] En sårbarhet som tillåter körning av
+    godtyckliga kommandon eller kod på en måldator.
+
+    \item [\textbf{\stoe}] (\emph{The Selective Symbolic Execution Platform}, jfr. sv. ), är
     en platform som tillhandahåller symbolisk exekvering inuti den virtuella
-    maskinen QEMU.\@
+    maskinen QEMU.
 
-    \item [\textbf{SMT Solver}] En Satisfiability modulo theories-lösare är ett
+    \item [\textbf{SMT-lösare}] (\emph{Satisfiability Modulo Theories}, jfr. sv. ) är ett
     program som kan lösa ekvationssystem för olika matematiska objekt. Exempel
     på teorier är modulär aritmetik eller bitvektorer. En SMT-lösare kan till
     exempel lösa ekvationer konstruerade i symbolisk exekvering.
@@ -57,19 +65,12 @@
     analysteknik kan enskilda körningar ge information som annars hade krävt
     en uttömmande sökning.
 
-    \item [\textbf{Symbolisk fuzzing}] Symbolisk fuzzing är en teknik som
-    kombinerar teknikerna symbolisk exekvering och fuzzing. Kombinationen
-    bevarar kodstrukturen och kan samtidigt lösa komplexa symboliska
-    restriktioner.
+    \item [\textbf{Symbolisk fuzztestning}] Teknik som kombinerar symbolisk exekvering
+    och fuzzingtestning. Kombinationen  bevarar kodstrukturen och kan samtidigt
+    lösa komplexa symboliska restriktioner.
 
-    \item [\textbf{White-box}] En analysmetod som behandlar en applikations
-    interna struktur i kontrast till black-box som enbart betraktar
-    funktionaliteten.
+    \item [\textbf{White-box analys}] (jfr. sv. vitlådsanalys) är en analysmetod
+    som behandlar en applikations interna struktur i kontrast till black-box
+    analys som enbart betraktar funktionaliteten.
 
-    \item [\textbf{Ransomware}] Gisslanprogram. En sorts skadeprogram som syftar
-    till att göra ett it-system oanvändbar genom kryptering av data som
-    endast kan avkrypteras med en nyckel.
-
-    \item [\textbf{Remote code execution}] En sårbarhet som tillåter körning av
-    godtyckliga kommandon eller kod på en måldator.
 \end{labeling}


### PR DESCRIPTION
Att diskutera: vilka begrepp ska vi ha i begreppslitan? För just nu har vi en hel del begrepp där vi använder dem med deras standarddefinition, och det hade antagligen gått att bara referera till encyklopedin som biblioteket rekommenderade. 