### PR TITLE
report: link to amba-bsc-thesis repo

### DIFF
--- a/doc/report/amba/main.tex
+++ b/doc/report/amba/main.tex
@@ -101,7 +101,7 @@ utvecklingsmöjligheter i avsnittet \nameref{sec:futurework}.
 
 \section{Hur du kör AMBA}\label{sec:run-amba}
 
-AMBA utvecklas i GitHub-repot
+AMBA utvecklades i GitHub-repot
 \url{https://github.com/lokegustafsson/amba-bsc-thesis}. Dokumentationen i repot
 innehåller mer detaljerade installationsinstruktioner och allmän dokumentation.
 


### PR DESCRIPTION
So that we can create a repo there and archive it, to continue development in this repo